### PR TITLE
Add output logging for GA runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@
 # CMake files
 /build
 /bin
+/output

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # VRP-EA-optimization
 Repository dedicated to solving the Vehicle Routing Problem (VRP) using an Evolutionary Algorithm (EA). Includes heuristic-based optimization approaches and implementation details for efficient route planning.
+
+## Output Files
+
+Running the program now saves results to the `output` directory:
+
+* `output/results.csv` &ndash; contains a CSV table of run number and best cost, followed by the average and best cost across all runs.
+* `output/run_<n>_routes.txt` &ndash; for each run `n`, lists the routes of all vehicles.
+
+These files can be parsed by external scripts (for example, in Python) to generate graphs or further analyses.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,8 @@
 #include <vector>
 #include <numeric> // For std::accumulate
 #include <algorithm>
+#include <fstream>
+#include <filesystem>
 
 int main()
 {
@@ -17,6 +19,11 @@ int main()
         std::cerr << "No VRP data loaded. Exiting..." << std::endl;
         return 1;
     }
+
+    // Prepare output directory and file for results
+    std::filesystem::create_directories("output");
+    std::ofstream resultsFile("output/results.csv");
+    resultsFile << "run,cost\n";
 
     const int runs = 10;         // Number of runs
     std::vector<double> results; // Store the results of each run
@@ -32,9 +39,13 @@ int main()
         double cost = ga.getBestSolutionCost(); // Assuming this method exists to get the cost.
         results.push_back(cost);
 
+        resultsFile << (i + 1) << "," << cost << "\n";
+
         std::cout << "Run #" << (i + 1) << " cost: " << cost << std::endl;
         std::cout << "Best solution (routes):" << std::endl;
         auto bestSolution = ga.getBestSolution();
+
+        std::ofstream routeFile("output/run_" + std::to_string(i + 1) + "_routes.txt");
 
         for (size_t vehicle = 0; vehicle < bestSolution.size(); ++vehicle)
         {
@@ -42,17 +53,22 @@ int main()
             if (!route.empty())
             {
                 std::cout << "Vehicle " << (vehicle + 1) << " route: ";
+                routeFile << "Vehicle " << (vehicle + 1) << ":";
                 for (int node : route)
                 {
                     std::cout << node << " ";
+                    routeFile << ' ' << node;
                 }
                 std::cout << std::endl;
+                routeFile << "\n";
             }
             else
             {
                 std::cout << "Vehicle " << (vehicle + 1) << " has no assigned route." << std::endl;
+                routeFile << "Vehicle " << (vehicle + 1) << ":" << "\n";
             }
         }
+        routeFile.close();
     }
 
     // Calculate the average cost.
@@ -60,6 +76,10 @@ int main()
     std::cout << "Average cost over " << runs << " runs: " << averageCost << std::endl;
     double bestCost = *std::min_element(results.begin(), results.end());
     std::cout << "Best cost over " << runs << " runs: " << bestCost << std::endl;
+
+    resultsFile << "average," << averageCost << "\n";
+    resultsFile << "best," << bestCost << "\n";
+    resultsFile.close();
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- generate CSV output of GA run results
- save per-run route files
- ignore new output directory
- document output files in README

## Testing
- `make build`
- `make test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c45048e4832cbc020f025d999d28